### PR TITLE
Issue #12 #18 : Ajout des liens pour les pages wiki dans les fichier open source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. 
+email, or any other method with the owners of this repository before making a change.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
@@ -15,6 +15,7 @@ the developers managing and developing this open source project. In return,
 they should reciprocate that respect in addressing your issue or assessing
 patches and features.
 
+If you would like to contribute, take the time to read the project's [wiki pages](https://github.com/Needlify/Needlify-v2/wiki). They group together all the manipulations to be carried out in the case of pull requests, which formalism to use in commits or issues, ...
 
 ## Using the issue tracker
 
@@ -22,11 +23,10 @@ The issue tracker is the preferred channel for [bug reports](#bugs),
 [features requests](#features) and [submitting pull
 requests](#pull-requests), but please respect the following restrictions:
 
-* Please **do not** use the issue tracker for personal support requests.
+-  Please **do not** use the issue tracker for personal support requests.
 
-* Please **do not** derail or troll issues. Keep the discussion on topic and
-  respect the opinions of others.
-
+-  Please **do not** derail or troll issues. Keep the discussion on topic and
+   respect the opinions of others.
 
 ## Bug reports
 
@@ -65,14 +65,12 @@ Example:
 > causing the bug, and potential solutions (and your opinions on their
 > merits).
 
-
 ## Feature requests
 
 Feature requests are welcome. But take a moment to find out whether your idea
-fits with the scope and aims of the project. It's up to *you* to make a strong
+fits with the scope and aims of the project. It's up to _you_ to make a strong
 case to convince the project's developers of the merits of this feature. Please
 provide as much detail and context as possible.
-
 
 ## Pull requests
 
@@ -95,13 +93,13 @@ project:
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
 license your work under the same license as that used by the project.
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
    build.
-2. Update the Wikis with details of changes to the interface, this includes new environment 
+2. Update the Wikis with details of changes to the interface, this includes new environment
    variables, exposed ports, useful file locations and container parameters.
 3. Increase the version numbers in any examples files and the README.md to the new version that this
    Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
    do not have permission to do that, you may request the second reviewer to merge it for you.
 
 ### Accepting patches

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This section is dedicated to the documentation of Needlify. In the [documentatio
 
 Thank you for considering contributing to the Needlify project ! The contribution guide can be found in the [contributing file](https://github.com/Needlify/Needlify-v2/blob/master/CONTRIBUTING.md).
 
-In order to maintain some consistency in the code, be sure to read the documents in the Wikis section of this repository. They contain all the elements you need to know to contribute to this project.
+In order to maintain some consistency in the code, be sure to read the documents in the [Wikis section](https://github.com/Needlify/Needlify-v2/wiki) of this repository. They contain all the elements you need to know to contribute to this project.
 
 If notions are missing, you can notify it by creating an issue.
 


### PR DESCRIPTION
**Issue de référence** : 
- Créer les fichiers pour Open Source #18
- Créer les pages de wiki #21

## Description

Création et ajout des pages de wiki dans les fichiers d'open source (readme et contributing)

## Type de changement

- [ ] Bug fix
- [x] New feature
- [ ] Changement majeur
- [ ] Ce changement nécessite une mise à jour de la documentation

## Screenshots

## Checklist
Vérifier que chaque élément de la liste suivante soit respecté avant d'effectuer un merge

- [x] La description du changement est correctement renseignée
- [ ] Des screenshots sont attachés dansla section correspondante si une page a été modifiée visuellement ou ajoutée
- [x] Pas de conflits entre les branches
- [x] La merge request est créée à partir de la bonne branche et cible la bonne branche
- [ ] Le code est correctement factorisé (pas de duplication de code)
- [ ] Les noms de variables et des fonctions ont du sens
- [ ] Il y a suffisamment de commentaires lorsque le code est compliqué
- [ ] L'indentation du code est correcte
- [ ] Les tests unitaires et fonctionnels ont été mis à jour
- [ ] Les tests unitaires et fonctionnales sont toujours valides
